### PR TITLE
String.includes() -> RegExp.test()

### DIFF
--- a/src/editTable.ts
+++ b/src/editTable.ts
@@ -5,7 +5,7 @@ import * as DBI from './interfaceSQL';
 //db.configure('busyTimeout', 5000);
 
 function sanitize(input: string) :string {
-  let hasComment = input.includes('--');
+  let hasComment = /--/.test(input);
   return (input.split('').filter( (c) => {
     return (
       (hasComment ? c !== '-' : true) && //remove dashes only if hasComment


### PR DESCRIPTION
EC2 said the error was that 'String.includes()'  does not exist. It does in ES6 and (basically) therefore Typescript, however we transpile to ES5 and this case is (silently) not handled by Typescript.
I have replaced this function with a regular expression.

This problem may have been caused by my removal of the need for the --downLevelIteration flag when I changed [...string] to string.split('').