### PR TITLE
add dont_mix to aggregate. fix tests, force in /lineGraph

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -26,12 +26,12 @@ export async function getLineGraphAPI(
   }
 
   //ALWAYS aggregate player's data seperately
-  if (influxRequest.aggregate === undefined ) {
-    influxRequest.aggregate = { dont_mix: ['players'] };
-  } else if (influxRequest.aggregate.dont_mix === undefined) {
-    influxRequest.aggregate.dont_mix = ['players'];
-  } else if (!influxRequest.aggregate.dont_mix.includes('players')) {
-    influxRequest.aggregate.dont_mix.push('players');
+  if (influxRequest.aggregate !== undefined ) {
+    if (influxRequest.aggregate.dont_mix === undefined) {
+      influxRequest.aggregate.dont_mix = ['players'];
+    } else if (!influxRequest.aggregate.dont_mix.includes('players')) {
+      influxRequest.aggregate.dont_mix.push('players');
+    }
   }
   //perform query
   const influxResponse = await executeInflux(buildQuery(influxRequest), queryClient);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,7 @@
 import { assert, expect } from 'chai';
 import startExpressServer from '../src';
 import request, { SuperAgentTest } from 'supertest';
+import { InfluxColumn } from 'src/utilsInflux';
 
 function assertSessionResponse(session: any) {
   assert.isObject(session);
@@ -531,7 +532,7 @@ describe('Test Express server endpoints', async () => {
         sessions: ['NULL 24/4/22'],
         teams: ['TeamWanchester'],
         fields: ['Velocity'],
-        aggregate: { every: '3600', func: 'mean' },
+        aggregate: { every: '3600', func: 'mean', dont_mix: ['players'] as InfluxColumn[] },
       });
       expect(res.statusCode).to.equal(200);
       assertTimeSeriesResponse(res.body);
@@ -543,7 +544,7 @@ describe('Test Express server endpoints', async () => {
         sessions: ['NULL 24/4/22'],
         teams: ['TeamWanchester'],
         fields: ['Velocity'],
-        aggregate: {},
+        aggregate: { dont_mix: ['players'] },
       });
       expect(res.statusCode).to.equal(200);
       assertTimeSeriesResponse(res.body);
@@ -609,7 +610,7 @@ describe('Test Express server endpoints', async () => {
       const res = await agent.post('/lineGraph').send({
         teams: ['Team3'],
         fields: ['Velocity'],
-        aggregate: { every: '3600', func: 'mean' },
+        aggregate: { every: '3600', func: 'mean', dont_mix: ['players'] },
       });
       expect(res.statusCode).to.equal(403);
     }).timeout(6000);
@@ -669,7 +670,7 @@ describe('Test Express server endpoints', async () => {
         sessions: ['NULL 17/4/22', 'NULL 2/4/22'],
         teams: ['TeamBit', 'Team3'],
         fields: ['Velocity', 'Height'],
-        aggregate: { every: '3600', period: 86400, func: 'timedMovingAverage' },
+        aggregate: { every: '3600', period: 86400, func: 'timedMovingAverage', dont_mix: ['players'] },
       });
       expect(res.statusCode).to.equal(200);
       assertTimeSeriesResponse(res.body);
@@ -679,7 +680,7 @@ describe('Test Express server endpoints', async () => {
       const res = await agent.post('/lineGraph').send({
         teams: ['TeamWanchester'],
         fields: ['Velocity'],
-        aggregate: { every: '3600', func: 'mean' },
+        aggregate: { every: '3600', func: 'mean', dont_mix: ['players'] },
       });
       expect(res.statusCode).to.equal(403);
     }).timeout(6000);
@@ -707,7 +708,7 @@ describe('Test Express server endpoints', async () => {
         sessions: ['NULL 17/4/22', 'NULL 2/4/22'],
         teams: ['TeamBit', 'Team3', 'TeamWanchester'],
         fields: ['Velocity', 'Height'],
-        aggregate: { func: 'mean' },
+        aggregate: { func: 'mean', dont_mix: ['players'] },
       });
       expect(res.statusCode).to.equal(200);
       assertTimeSeriesResponse(res.body);

--- a/test/index.ts
+++ b/test/index.ts
@@ -340,7 +340,7 @@ describe('Test Express server endpoints', async () => {
       expect(res.statusCode).to.equal(200);
       assert.isArray(res.body); 
       res.body.forEach((session: any)=>assertSessionResponse(session) );
-    });
+    }).timeout(4000);
 
     it('GET /trainingSessions?teamName=TeamWanchester fails with c_coach1 logged in as user', async () => {
       const res = await agent.get('/trainingSessions?teamName=TeamWanchester');
@@ -457,7 +457,7 @@ describe('Test Express server endpoints', async () => {
       const res = await agent.get('/trainingSessions?teamName=TeamBit');
       expect(res.statusCode).to.equal(200);
       res.body.forEach((session: any)=>assertSessionResponse(session) );
-    });
+    }).timeout(4000);
 
     it('GET /trainingSessions?teamName=TeamWanchester succeeds with a_administrator logged in as user', async () => {
       const res = await agent.get('/trainingSessions?teamName=TeamWanchester');


### PR DESCRIPTION
Allows control of the grouping of data for aggregation. For instance, a user may want a list of all team member's maximum velocities, or they may want a team's overall fastest recorded velocity.
{
  fields: ["Velocity"], 
  teams: ["TeamBit"],
  aggregate: {
    func: "max", 
    dont_mix: ["players"]
  }
}

versus

{
  fields: ["Velocity"], 
  teams: ["TeamBit"],
  aggregate: {
    func: "max"
  }
}
respectively